### PR TITLE
Rework Marathon UI fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lazy.js": "^0.4.0",
     "moment": "^2.9.0",
     "mousetrap": "^1.4.6",
+    "mustache": "^2.3.0",
     "object-path": "^0.9.2",
     "react": "^0.13.2",
     "react-ace": "^3.1.0",

--- a/src/css/components/app-list.less
+++ b/src/css/components/app-list.less
@@ -15,6 +15,10 @@
       width: auto;
     }
 
+    &.logs-link-col {
+      width: @base-spacing-unit*7;
+    }
+
     &.ram-col {
       width: @base-spacing-unit*12;
     }

--- a/src/css/components/app-list.less
+++ b/src/css/components/app-list.less
@@ -19,6 +19,10 @@
       width: @base-spacing-unit*7;
     }
 
+    &.service-link-col {
+      width: @base-spacing-unit*7;
+    }
+
     &.ram-col {
       width: @base-spacing-unit*12;
     }

--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,7 @@
   <body>
     <div id="marathon"></div>
 
+    <script src="runtimeConfig.js"></script>
     <script src="main.js"></script>
   </body>
 </html>

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -476,6 +476,8 @@ var AppListComponent = React.createClass({
 
     var logsLinkClassSet = classNames("text-right logs-cell");
 
+    var serviceLinkClassSet = classNames("text-right service-cell");
+
     var cpuClassSet = classNames("text-right cpu-cell", {
       "cell-highlighted": state.sortKey === "totalCpus"
     });
@@ -518,6 +520,7 @@ var AppListComponent = React.createClass({
           <colgroup>
             <col className="icon-col" />
             <col className="name-col" />
+            <col className="service-link-col" />
             <col className="logs-link-col" />
             <col className="cpu-col" />
             <col className="ram-col" />
@@ -532,6 +535,11 @@ var AppListComponent = React.createClass({
                 <span onClick={this.sortBy.bind(null, "id")}
                     className={headerClassSet}>
                   Name {this.getCaret("id")}
+                </span>
+              </th>
+              <th className={serviceLinkClassSet}>
+                <span className={headerClassSet}>
+                  Service
                 </span>
               </th>
               <th className={logsLinkClassSet}>

--- a/src/js/components/AppListComponent.jsx
+++ b/src/js/components/AppListComponent.jsx
@@ -474,6 +474,8 @@ var AppListComponent = React.createClass({
       "cell-highlighted": state.sortKey === "id"
     });
 
+    var logsLinkClassSet = classNames("text-right logs-cell");
+
     var cpuClassSet = classNames("text-right cpu-cell", {
       "cell-highlighted": state.sortKey === "totalCpus"
     });
@@ -516,6 +518,7 @@ var AppListComponent = React.createClass({
           <colgroup>
             <col className="icon-col" />
             <col className="name-col" />
+            <col className="logs-link-col" />
             <col className="cpu-col" />
             <col className="ram-col" />
             <col className="status-col" />
@@ -529,6 +532,11 @@ var AppListComponent = React.createClass({
                 <span onClick={this.sortBy.bind(null, "id")}
                     className={headerClassSet}>
                   Name {this.getCaret("id")}
+                </span>
+              </th>
+              <th className={logsLinkClassSet}>
+                <span className={headerClassSet}>
+                  Logs
                 </span>
               </th>
               <th className={cpuClassSet}>

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import React from "react/addons";
 import OnClickOutsideMixin from "react-onclickoutside";
+import Mustache from "mustache";
 
 import AppActionsHandlerMixin from "../mixins/AppActionsHandlerMixin";
 import AppHealthBarWithTooltipComponent
@@ -15,6 +16,11 @@ import Util from "../helpers/Util";
 import PathUtil from "../helpers/PathUtil";
 import PopoverComponent from "./PopoverComponent";
 import DOMUtil from "../helpers/DOMUtil";
+import Config from "../config/config";
+
+function handleClickAndStopPropagation(e) {
+  e.stopPropagation();
+}
 
 var AppListItemComponent = React.createClass({
   displayName: "AppListItemComponent",
@@ -319,6 +325,20 @@ var AppListItemComponent = React.createClass({
     return <i className="icon icon-small app" title="Application"></i>;
   },
 
+  getLogsLink: function () {
+    var model = this.props.model;
+    if (model.isGroup)
+      return null;
+
+    const logsLink = Mustache.render(Config.appLogsLinkTemplate, {
+      appId: encodeURIComponent(model.id.substring(1))
+    });
+    return (<a href={logsLink} target="_blank"
+        onClick={handleClickAndStopPropagation}>
+      <div className="icon icon-mini file"></div>
+    </a>);
+  },
+
   getLabels: function () {
     var labels = this.props.model.labels;
     if (labels == null || Object.keys(labels).length === 0) {
@@ -366,6 +386,8 @@ var AppListItemComponent = React.createClass({
       "cell-highlighted": sortKey === "id"
     });
 
+    var appLogsLinkClassSet = classNames("text-right logs-cell");
+
     var cpuClassSet = classNames("text-right total cpu-cell", {
       "cell-highlighted": sortKey === "totalCpus"
     });
@@ -384,6 +406,9 @@ var AppListItemComponent = React.createClass({
           {this.getIcon()}
         </td>
         {this.getAppName()}
+        <td className={appLogsLinkClassSet}>
+          {this.getLogsLink()}
+        </td>
         <td className={cpuClassSet}>
           {parseFloat(model.totalCpus).toFixed(1)}
         </td>

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -360,6 +360,26 @@ var AppListItemComponent = React.createClass({
     );
   },
 
+  getServiceLink: function () {
+    var model = this.props.model;
+    var scheme = (model.labels && "SERVICE_SCHEME" in model.labels &&
+       (model.labels["SERVICE_SCHEME"] === "http" ||
+        model.labels["SERVICE_SCHEME"] === "https"))
+      ? model.labels["SERVICE_SCHEME"]
+      : "http";
+    var cleanAppName = model.id.substring(1).replace("/", "-");
+    var serviceLink = scheme + "://" + cleanAppName + "." +
+      Config.serviceDomain;
+
+    if (model.isGroup)
+      return null;
+
+    return (<a href={serviceLink} target="_blank"
+          onClick={handleClickAndStopPropagation}>
+        <div className="icon icon-small ion-forward"></div>
+    </a>);
+  },
+
   getStatus: function () {
     var classSet = classNames("status-cell", {
       "cell-highlighted": this.props.sortKey === "status"
@@ -386,6 +406,8 @@ var AppListItemComponent = React.createClass({
       "cell-highlighted": sortKey === "id"
     });
 
+    var serviceLinkClassSet = classNames("text-right service-cell");
+
     var appLogsLinkClassSet = classNames("text-right logs-cell");
 
     var cpuClassSet = classNames("text-right total cpu-cell", {
@@ -406,6 +428,9 @@ var AppListItemComponent = React.createClass({
           {this.getIcon()}
         </td>
         {this.getAppName()}
+        <td className={serviceLinkClassSet}>
+          {this.getServiceLink()}
+        </td>
         <td className={appLogsLinkClassSet}>
           {this.getLogsLink()}
         </td>

--- a/src/js/config/config.js
+++ b/src/js/config/config.js
@@ -15,6 +15,7 @@ var config = {
     address: "localhost",
     port: 8181
   },
+  appLogsLinkTemplate: "#",
   version: ("@@TEAMCITY_UI_VERSION".indexOf("@@TEAMCITY") === -1) ?
     "@@TEAMCITY_UI_VERSION" :
     `${packageJSON.version}-SNAPSHOT`

--- a/src/js/config/config.js
+++ b/src/js/config/config.js
@@ -16,6 +16,7 @@ var config = {
     port: 8181
   },
   appLogsLinkTemplate: "#",
+  serviceDomain: "",
   version: ("@@TEAMCITY_UI_VERSION".indexOf("@@TEAMCITY") === -1) ?
     "@@TEAMCITY_UI_VERSION" :
     `${packageJSON.version}-SNAPSHOT`

--- a/src/js/config/config.js
+++ b/src/js/config/config.js
@@ -1,6 +1,6 @@
 import packageJSON from "../../../package.json";
 
-var config = {
+var config = Object.assign({
   // @@ENV gets replaced by build system
   environment: "@@ENV",
   // If the UI is served through a proxied URL, this can be set here.
@@ -20,6 +20,6 @@ var config = {
   version: ("@@TEAMCITY_UI_VERSION".indexOf("@@TEAMCITY") === -1) ?
     "@@TEAMCITY_UI_VERSION" :
     `${packageJSON.version}-SNAPSHOT`
-};
+}, runtimeConfig);
 
 export default config;

--- a/src/js/config/runtimeConfig.template.js
+++ b/src/js/config/runtimeConfig.template.js
@@ -1,0 +1,9 @@
+// This runtime configuration will be fetched during loading of the main page
+// and merged with the static configuration
+var runtimeConfig = {
+  // The domain used to compute the service endpoint
+  serviceDomain: "marathon.service.domain",
+
+  // The pattern to build the links to the logs
+  appLogsLinkTemplate: "http://logs-store-like-kibana/?appId={{appId}}",
+};

--- a/src/js/stores/schemes/appScheme.js
+++ b/src/js/stores/schemes/appScheme.js
@@ -5,7 +5,7 @@ import AppTypes from "../../constants/AppTypes";
 const appScheme = {
   cmd: null,
   constraints: [],
-  acceptedResourceRoles: [],
+  acceptedResourceRoles: null,
   container: null,
   cpus: null,
   dependencies: [],

--- a/src/test/environment/jsdom.js
+++ b/src/test/environment/jsdom.js
@@ -10,3 +10,4 @@ global.document = jsdom.jsdom(html, {
 });
 global.window = document.defaultView;
 global.navigator = window.navigator;
+global.runtimeConfig = {};

--- a/src/test/units/AppListItemComponent.test.js
+++ b/src/test/units/AppListItemComponent.test.js
@@ -3,6 +3,9 @@ import {render} from "enzyme";
 
 import React from "react/addons";
 import AppListItemComponent from "../../js/components/AppListItemComponent";
+import config from "../../js/config/config";
+
+config.appLogsLinkTemplate = "http://kibana?appId={{appId}}";
 
 describe("AppListItemComponent", function () {
 
@@ -17,7 +20,7 @@ describe("AppListItemComponent", function () {
       totalMem: 1030,
       cpus: 4,
       totalCpus: 20.0000001,
-      status: 0
+      status: 0,
     };
 
     this.component = render(
@@ -37,6 +40,13 @@ describe("AppListItemComponent", function () {
     expect(this.component.find(".cpu-cell").text()).to.equal("20.0");
   });
 
+  it("has the correct link to logs", function () {
+    expect(this.component.find(".logs-cell").find("a").html())
+      .to.equal("<div class=\"icon icon-mini file\"></div>");
+    expect(this.component.find(".logs-cell").find("a").attr("href"))
+      .to.equal("http://kibana?appId=app-123");
+  });
+
   it("has the correct amount of total memory", function () {
     var node = this.component.find(".total.ram > span");
     expect(node.get(0).attribs.title).to.equal("1030 MiB");
@@ -51,7 +61,34 @@ describe("AppListItemComponent", function () {
       .to.equal("4 of 5");
   });
 
-  describe("has highlight in the sorted column", function(){
+  describe("entry is a group", function () {
+    before(function () {
+      var model = {
+        id: "/app-123",
+        deployments: [],
+        tasksRunning: 4,
+        health: [],
+        instances: 5,
+        mem: 100,
+        totalMem: 1030,
+        cpus: 4,
+        totalCpus: 20.0000001,
+        status: 0,
+        isGroup: true
+      };
+
+      this.component = render(
+        <AppListItemComponent model={model} currentGroup="/" />
+      );
+    });
+
+    it("does not display log icon for groups", function () {
+      expect(this.component.find(".logs-cell").html())
+        .to.be.empty;
+    });
+  });
+
+  describe("has highlight in the sorted column", function (){
     var testCases = [
       {
         sortKey: "id",

--- a/src/test/units/AppListItemComponent.test.js
+++ b/src/test/units/AppListItemComponent.test.js
@@ -6,9 +6,9 @@ import AppListItemComponent from "../../js/components/AppListItemComponent";
 import config from "../../js/config/config";
 
 config.appLogsLinkTemplate = "http://kibana?appId={{appId}}";
+config.serviceDomain = "service.domain";
 
 describe("AppListItemComponent", function () {
-
   before(function () {
     var model = {
       id: "/app-123",
@@ -45,6 +45,57 @@ describe("AppListItemComponent", function () {
       .to.equal("<div class=\"icon icon-mini file\"></div>");
     expect(this.component.find(".logs-cell").find("a").attr("href"))
       .to.equal("http://kibana?appId=app-123");
+  });
+
+  describe("produces the correct service link", function () {
+    it("has an http scheme when no scheme is provided", function () {
+      expect(this.component.find(".service-cell").find("a").attr("href"))
+        .to.equal("http://app-123.service.domain");
+    });
+
+    it("has an https scheme when SERVICE_SCHEME is https", function () {
+      var model = {
+        id: "/app-123",
+        deployments: [],
+        tasksRunning: 4,
+        health: [],
+        instances: 5,
+        mem: 100,
+        totalMem: 1030,
+        cpus: 4,
+        totalCpus: 20.0000001,
+        status: 0,
+        labels: {"SERVICE_SCHEME": "https"},
+      };
+
+      var component = render(
+        <AppListItemComponent model={model} currentGroup="/" />
+      );
+      expect(component.find(".service-cell").find("a").attr("href"))
+        .to.equal("https://app-123.service.domain");
+    });
+
+    it("fallbacks to http scheme when SERVICE_SCHEME is wrong", function () {
+      var model = {
+        id: "/app-123",
+        deployments: [],
+        tasksRunning: 4,
+        health: [],
+        instances: 5,
+        mem: 100,
+        totalMem: 1030,
+        cpus: 4,
+        totalCpus: 20.0000001,
+        status: 0,
+        labels: {"SERVICE_SCHEME": "unknown-scheme"},
+      };
+
+      var component = render(
+        <AppListItemComponent model={model} currentGroup="/" />
+      );
+      expect(component.find(".service-cell").find("a").attr("href"))
+        .to.equal("http://app-123.service.domain");
+    });
   });
 
   it("has the correct amount of total memory", function () {


### PR DESCRIPTION
I split and fixed the features that have been developed in the Criteo version of the Marathon UI.

This PR introduces two new columns in the main page: "Logs" and "Service" which are, for each application, filled with a link to the application logs (customizable in the runtime configuration) and a link to the service endpoint.