### PR TITLE
Produce logs links using user callback and add logs for each task

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "lazy.js": "^0.4.0",
     "moment": "^2.9.0",
     "mousetrap": "^1.4.6",
-    "mustache": "^2.3.0",
     "object-path": "^0.9.2",
     "react": "^0.13.2",
     "react-ace": "^3.1.0",

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -1,7 +1,6 @@
 import classNames from "classnames";
 import React from "react/addons";
 import OnClickOutsideMixin from "react-onclickoutside";
-import Mustache from "mustache";
 
 import AppActionsHandlerMixin from "../mixins/AppActionsHandlerMixin";
 import AppHealthBarWithTooltipComponent
@@ -330,10 +329,7 @@ var AppListItemComponent = React.createClass({
     if (model.isGroup)
       return null;
 
-    const logsLink = Mustache.render(Config.appLogsLinkTemplate, {
-      appId: encodeURIComponent(model.id.substring(1))
-    });
-    return (<a href={logsLink} target="_blank"
+    return (<a href={Config.appLogsLinkGenerator(model.id)} target="_blank"
         onClick={handleClickAndStopPropagation}>
       <div className="icon icon-mini file"></div>
     </a>);

--- a/src/js/components/TaskListComponent.jsx
+++ b/src/js/components/TaskListComponent.jsx
@@ -225,10 +225,7 @@ var TaskListComponent = React.createClass({
                 </span>
               </th>
               <th className="text-center">
-                Error Log
-              </th>
-              <th className="text-center">
-                Output Log
+                Logs
               </th>
               <th className={versionClassSet}>
                 <span onClick={this.sortBy.bind(null, "version")}

--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -6,7 +6,7 @@ import Moment from "moment";
 import AppsStore from "../stores/AppsStore";
 import HealthStatus from "../constants/HealthStatus";
 import TaskStatus from "../constants/TaskStatus";
-import TaskFileDownloadComponent from "../components/TaskFileDownloadComponent";
+import Config from "../config/config";
 
 function joinNodes(nodes, separator = ", ") {
   var lastIndex = nodes.length - 1;
@@ -150,6 +150,12 @@ var TaskListItemComponent = React.createClass({
     this.props.onToggle(this.props.task, event.target.checked);
   },
 
+  getLogsLink: function () {
+    const logsLink = Config.taskLogsLinkGenerator(this.props.appId,
+      this.props.task.id);
+    return <a href={logsLink} target="_blank">Logs</a>;
+  },
+
   render: function () {
     var task = this.props.task;
     var sortKey = this.props.sortKey;
@@ -238,10 +244,7 @@ var TaskListItemComponent = React.createClass({
           </span>
         </td>
         <td className="text-center">
-          <TaskFileDownloadComponent task={task} fileName="stderr" />
-        </td>
-        <td className="text-center">
-          <TaskFileDownloadComponent task={task} fileName="stdout" />
+          {this.getLogsLink()}
         </td>
         <td className={versionClassSet}>
           <span title={version}>

--- a/src/js/config/config.js
+++ b/src/js/config/config.js
@@ -15,7 +15,12 @@ var config = Object.assign({
     address: "localhost",
     port: 8181
   },
-  appLogsLinkTemplate: "#",
+  // The generator building the logs links for applications
+  // input: appId
+  // output: the link to the logs
+  appLogsLinkGenerator: function () { 
+    return ""; 
+  },
   serviceDomain: "",
   version: ("@@TEAMCITY_UI_VERSION".indexOf("@@TEAMCITY") === -1) ?
     "@@TEAMCITY_UI_VERSION" :

--- a/src/js/config/config.js
+++ b/src/js/config/config.js
@@ -21,6 +21,12 @@ var config = Object.assign({
   appLogsLinkGenerator: function () { 
     return ""; 
   },
+  // The generator building the logs links for tasks
+  // input: appId, taskId
+  // output: the link to the logs
+  taskLogsLinkGenerator: function () {
+    return "";
+  },
   serviceDomain: "",
   version: ("@@TEAMCITY_UI_VERSION".indexOf("@@TEAMCITY") === -1) ?
     "@@TEAMCITY_UI_VERSION" :

--- a/src/js/config/runtimeConfig.template.js
+++ b/src/js/config/runtimeConfig.template.js
@@ -7,5 +7,10 @@ var runtimeConfig = {
   // The generator building the logs links for applications
   appLogsLinkGenerator: function (appId) {
     return "http://logs-store-like-kibana/?appId=" + appId.substring(1);
+  },
+
+  // The generator building the logs links for tasks
+  taskLogsLinkGenerator: function (appId, taskId) {
+    return "http://logs-store-like-kibana/?appId=" + appId.substring(1) + "&taskId=" + taskId;
   }
 };

--- a/src/js/config/runtimeConfig.template.js
+++ b/src/js/config/runtimeConfig.template.js
@@ -4,6 +4,8 @@ var runtimeConfig = {
   // The domain used to compute the service endpoint
   serviceDomain: "marathon.service.domain",
 
-  // The pattern to build the links to the logs
-  appLogsLinkTemplate: "http://logs-store-like-kibana/?appId={{appId}}",
+  // The generator building the logs links for applications
+  appLogsLinkGenerator: function (appId) {
+    return "http://logs-store-like-kibana/?appId=" + appId.substring(1);
+  }
 };

--- a/src/test/units/AppListItemComponent.test.js
+++ b/src/test/units/AppListItemComponent.test.js
@@ -5,7 +5,9 @@ import React from "react/addons";
 import AppListItemComponent from "../../js/components/AppListItemComponent";
 import config from "../../js/config/config";
 
-config.appLogsLinkTemplate = "http://kibana?appId={{appId}}";
+config.appLogsLinkGenerator = function (appId) {
+  return "http://kibana?appId=" + appId.substring(1);
+};
 config.serviceDomain = "service.domain";
 
 describe("AppListItemComponent", function () {

--- a/src/test/units/TaskListItemComponent.test.js
+++ b/src/test/units/TaskListItemComponent.test.js
@@ -3,6 +3,11 @@ import {shallow} from "enzyme";
 
 import React from "react/addons";
 import TaskListItemComponent from "../../js/components/TaskListItemComponent";
+import Config from "../../js/config/config";
+
+Config.taskLogsLinkGenerator = function (appId, taskId) {
+  return "https://logs-store?appId=" + appId + "&taskId=" + taskId;
+}
 
 describe("Task List Item component", function () {
 
@@ -48,7 +53,7 @@ describe("Task List Item component", function () {
   it("has the correct version", function () {
     expect(this.component
       .find("td")
-      .at(6)
+      .at(5)
       .children()
       .first()
       .props()
@@ -59,7 +64,7 @@ describe("Task List Item component", function () {
   it("has the correct update timestamp", function () {
     var cellProps = this.component
       .find("td")
-      .at(7)
+      .at(6)
       .children()
       .first()
       .props();
@@ -67,4 +72,13 @@ describe("Task List Item component", function () {
     expect(cellProps.dateTime).to.equal("2015-06-29T14:11:58.709Z");
   });
 
+  it("has the correct logs link", function () {
+    var a = this.component
+    .find("td")
+    .at(4)
+    .children()
+    .first()
+    .props();
+    expect(a.href).to.equal("https://logs-store?appId=/app-1&taskId=task-123");
+  });
 });


### PR DESCRIPTION
There are cases where the name of the application in the log store is not exactly the appId declared in Marathon. The new concept of link producers allow the user to customize the filter to apply for retrieving the logs.

A producer have also been implemented for per-task logs links that are available in the application view.