### PR TITLE
Use a label to select the scheme of links under task ID in task view

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,8 @@ services:
       - zookeeper
       - mesos-master
     environment:
-      - MESOS_CONTAINERIZERS=mesos
-      - MESOS_ISOLATOR=cgroups/cpu, cgroups/mem
+      - MESOS_CONTAINERIZERS=mesos,docker
+      - MESOS_ISOLATOR=cgroups/cpu, cgroups/mem, filesystem/linux, docker/runtime
       - MESOS_LOG_DIR=var/log
       - MESOS_MASTER=zk://zookeeper:2181/mesos
       - MESOS_PORT=5051
@@ -48,6 +48,8 @@ services:
       - MESOS_EXECUTOR_SHUTDOWN_GRACE_PERIOD=90secs
       - MESOS_DOCKER_STOP_TIMEOUT=60secs
       - MESOS_RESOURCES=cpus:4;mem:1280;disk:25600;ports(*):[12000-12999]
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
   marathon-service:
     image: mesosphere/marathon:latest
     expose:
@@ -79,7 +81,8 @@ services:
       - DNSDOCK_ALIAS=marathon.docker
     volumes:
       - ./resources/marathon-ui.nginx.conf:/etc/nginx/nginx.conf
-      -  dist:/usr/share/nginx/html
+      - dist:/usr/share/nginx/html
+      - ./src/js/config/runtimeConfig.js:/usr/share/nginx/html/runtimeConfig.js
   develop-environment:
     build:
         context: .

--- a/resources/marathon-ui.nginx.conf
+++ b/resources/marathon-ui.nginx.conf
@@ -38,6 +38,11 @@ http {
       index index.html;
     }
 
+    location /runtimeConfig.js {
+      alias /usr/share/nginx/html;
+      index runtimeConfig.js;
+    }
+
     location ~ /v2/(.+) {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/src/js/components/AppListItemComponent.jsx
+++ b/src/js/components/AppListItemComponent.jsx
@@ -15,6 +15,7 @@ import Util from "../helpers/Util";
 import PathUtil from "../helpers/PathUtil";
 import PopoverComponent from "./PopoverComponent";
 import DOMUtil from "../helpers/DOMUtil";
+import ServiceSchemeUtil from "../helpers/ServiceSchemeUtil";
 import Config from "../config/config";
 
 function handleClickAndStopPropagation(e) {
@@ -358,11 +359,7 @@ var AppListItemComponent = React.createClass({
 
   getServiceLink: function () {
     var model = this.props.model;
-    var scheme = (model.labels && "SERVICE_SCHEME" in model.labels &&
-       (model.labels["SERVICE_SCHEME"] === "http" ||
-        model.labels["SERVICE_SCHEME"] === "https"))
-      ? model.labels["SERVICE_SCHEME"]
-      : "http";
+    var scheme = ServiceSchemeUtil.getServiceSchemeFromLabels(model.labels, 0);
     var cleanAppName = model.id.substring(1).replace(/\//g, "-");
     var serviceLink = scheme + "://" + cleanAppName + "." +
       Config.serviceDomain;

--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -352,6 +352,7 @@ var AppPageComponent = React.createClass({
             fetchState={state.fetchState}
             getTaskHealthMessage={this.getTaskHealthMessage}
             hasHealth={Object.keys(model.healthChecks).length > 0}
+            labels={model.labels}
             tasks={model.tasks} />
         </TabPaneComponent>
         <TabPaneComponent

--- a/src/js/components/TaskListComponent.jsx
+++ b/src/js/components/TaskListComponent.jsx
@@ -17,6 +17,7 @@ var TaskListComponent = React.createClass({
     getTaskHealthMessage: React.PropTypes.func.isRequired,
     hasHealth: React.PropTypes.bool,
     itemsPerPage: React.PropTypes.number.isRequired,
+    labels: React.PropTypes.object.isRequired,
     onTaskToggle: React.PropTypes.func.isRequired,
     selectedTasks: React.PropTypes.object.isRequired,
     tasks: React.PropTypes.array.isRequired,
@@ -70,6 +71,7 @@ var TaskListComponent = React.createClass({
             onToggle={props.onTaskToggle}
             sortKey={sortKey}
             task={task}
+            labels={props.labels}
             taskHealthMessage={props.getTaskHealthMessage(task.id)} />
         );
       })

--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -7,6 +7,7 @@ import AppsStore from "../stores/AppsStore";
 import HealthStatus from "../constants/HealthStatus";
 import TaskStatus from "../constants/TaskStatus";
 import Config from "../config/config";
+import ServiceSchemeUtil from "../helpers/ServiceSchemeUtil";
 
 function joinNodes(nodes, separator = ", ") {
   var lastIndex = nodes.length - 1;
@@ -29,6 +30,7 @@ var TaskListItemComponent = React.createClass({
     appId: React.PropTypes.string.isRequired,
     hasHealth: React.PropTypes.bool,
     isActive: React.PropTypes.bool.isRequired,
+    labels: React.PropTypes.object.isRequired,
     onToggle: React.PropTypes.func.isRequired,
     sortKey: React.PropTypes.string,
     task: React.PropTypes.object.isRequired,
@@ -37,6 +39,7 @@ var TaskListItemComponent = React.createClass({
 
   getHostAndPorts: function () {
     var task = this.props.task;
+    var props = this.props;
     var ports = task.ports;
 
     if (ports == null || ports.length === 0 ) {
@@ -44,9 +47,11 @@ var TaskListItemComponent = React.createClass({
     }
 
     if (ports != null && ports.length === 1) {
+      const scheme = ServiceSchemeUtil
+        .getServiceSchemeFromLabels(props.labels, 0);
       return (
         <a className="text-muted"
-            href={`//${task.host}:${ports[0]}`}
+            href={`${scheme}://${task.host}:${ports[0]}`}
             target="_blank">
           {`${task.host}:${ports[0]}`}
         </a>
@@ -54,11 +59,13 @@ var TaskListItemComponent = React.createClass({
     }
 
     if (ports != null && ports.length > 1) {
-      let portNodes = ports.map(function (port) {
+      let portNodes = ports.map(function (port, i) {
+        const scheme = ServiceSchemeUtil
+          .getServiceSchemeFromLabels(props.labels, i);
         return (
           <a key={`${task.host}:${port}`}
               className="text-muted"
-              href={`//${task.host}:${port}`}
+              href={`${scheme}://${task.host}:${port}`}
               target="_blank">
             {port}
           </a>
@@ -98,18 +105,24 @@ var TaskListItemComponent = React.createClass({
         let ipAddress = address.ipAddress;
         if (serviceDiscoveryPorts.length === 1) {
           let port = serviceDiscoveryPorts[0].number;
+          const scheme = ServiceSchemeUtil
+            .getServiceSchemeFromLabels(props.labels, 0);
           return (
             <a key={`${ipAddress}:${port}`}
-                className="text-muted" href={`//${ipAddress}:${port}`}>
+                className="text-muted"
+                href={`${scheme}://${ipAddress}:${port}`}>
               {`${ipAddress}:${port}`}
             </a>
           );
         }
 
-        let portNodes = serviceDiscoveryPorts.map((port) => {
+        let portNodes = serviceDiscoveryPorts.map((port, i) => {
+          const scheme = ServiceSchemeUtil
+            .getServiceSchemeFromLabels(props.labels, i);
           return (
             <a key={`${ipAddress}:${port.number}`}
-                className="text-muted" href={`//${ipAddress}:${port.number}`}>
+                className="text-muted"
+                href={`${scheme}://${ipAddress}:${port.number}`}>
               {port.number}
             </a>
           );

--- a/src/js/components/TaskViewComponent.jsx
+++ b/src/js/components/TaskViewComponent.jsx
@@ -18,6 +18,7 @@ var TaskViewComponent = React.createClass({
     fetchState: React.PropTypes.number.isRequired,
     getTaskHealthMessage: React.PropTypes.func.isRequired,
     hasHealth: React.PropTypes.bool,
+    labels: React.PropTypes.object.isRequired,
     tasks: React.PropTypes.array.isRequired
   },
 
@@ -228,6 +229,7 @@ var TaskViewComponent = React.createClass({
           hasHealth={this.props.hasHealth}
           onTaskToggle={this.onTaskToggle}
           itemsPerPage={this.state.itemsPerPage}
+          labels={this.props.labels}
           selectedTasks={this.state.selectedTasks}
           tasks={this.props.tasks}
           toggleAllTasks={this.toggleAllTasks} />

--- a/src/js/config/config.js
+++ b/src/js/config/config.js
@@ -18,8 +18,8 @@ var config = Object.assign({
   // The generator building the logs links for applications
   // input: appId
   // output: the link to the logs
-  appLogsLinkGenerator: function () { 
-    return ""; 
+  appLogsLinkGenerator: function () {
+    return "";
   },
   // The generator building the logs links for tasks
   // input: appId, taskId

--- a/src/js/config/runtimeConfig.js
+++ b/src/js/config/runtimeConfig.js
@@ -1,0 +1,16 @@
+// This runtime configuration will be fetched during loading of the main page
+// and merged with the static configuration
+var runtimeConfig = {
+  // The domain used to compute the service endpoint
+  serviceDomain: "marathon.service.domain",
+
+  // The generator building the logs links for applications
+  appLogsLinkGenerator: function (appId) {
+    return "http://logs-store-like-kibana/?appId=" + appId.substring(1);
+  },
+
+  // The generator building the logs links for tasks
+  taskLogsLinkGenerator: function (appId, taskId) {
+    return "http://logs-store-like-kibana/?appId=" + appId.substring(1) + "&taskId=" + taskId;
+  }
+};

--- a/src/js/helpers/ServiceSchemeUtil.js
+++ b/src/js/helpers/ServiceSchemeUtil.js
@@ -1,0 +1,37 @@
+const BASE_SCHEME_LABEL = "MARATHON_SERVICE_SCHEME";
+const DEFAULT_SCHEME = "http";
+
+var ServiceSchemeUtil = {
+  /*
+   * Returns service scheme of the n-th port.
+   *
+   * Given N a port index, if `MARATHON_SERVICE_SCHEME_<N>` is
+   * in the set of labels, then the function returns the value
+   * of this label.
+   *
+   * Given N a port index, if `MARATHON_SERVICE_SCHEME_<N>` is
+   * not in the set of labels, then the value associated with
+   * `MARATHON_SERVICE_SCHEME` is returned.
+   *
+   * Given N a port index, if `MARATHON_SERVICE_SCHEME_<N>` and
+   * `MARATHON_SERVICE_SCHEME` are not in the set of labels, the
+   * function returns the `http` as the default scheme.
+   */
+  getServiceSchemeFromLabels(labels, n) {
+    function getScheme(labelValue) {
+      return (labelValue === "http" || labelValue === "https")
+        ? labelValue
+        : DEFAULT_SCHEME;
+    }
+
+    const labelKey = ("" + BASE_SCHEME_LABEL + "_" + n);
+    if (labels && labelKey in labels)
+      return getScheme(labels[labelKey]);
+    else if (labels && BASE_SCHEME_LABEL in labels)
+      return getScheme(labels[BASE_SCHEME_LABEL]);
+
+    return DEFAULT_SCHEME;
+  }
+};
+
+export default ServiceSchemeUtil;

--- a/src/test/units/AppListItemComponent.test.js
+++ b/src/test/units/AppListItemComponent.test.js
@@ -67,7 +67,7 @@ describe("AppListItemComponent", function () {
         cpus: 4,
         totalCpus: 20.0000001,
         status: 0,
-        labels: {"SERVICE_SCHEME": "https"},
+        labels: {"MARATHON_SERVICE_SCHEME": "https"},
       };
 
       var component = render(

--- a/src/test/units/ServiceSchemeUtil.test.js
+++ b/src/test/units/ServiceSchemeUtil.test.js
@@ -1,0 +1,56 @@
+import {expect} from "chai";
+import ServiceSchemeUtil from "../../js/helpers/ServiceSchemeUtil";
+
+function verifyServiceSchemeWithDefault(serviceScheme, serviceScheme0, 
+  expectedSchemePort0, expectedSchemePort1) {
+  describe("MARATHON_SERVICE_SCHEME is set to " + serviceScheme, function() {
+    describe("MARATHON_SERVICE_SCHEME_0 is set to " + serviceScheme0, function() {
+      it("detect scheme of port 0", function() {
+        expect(ServiceSchemeUtil.getServiceSchemeFromLabels({
+          "MARATHON_SERVICE_SCHEME": serviceScheme,
+          "MARATHON_SERVICE_SCHEME_0": serviceScheme0,
+        }, 0)).to.eq(expectedSchemePort0);
+      });
+
+      it("detect scheme of port 1", function() {
+        expect(ServiceSchemeUtil.getServiceSchemeFromLabels({
+          "MARATHON_SERVICE_SCHEME": serviceScheme,
+          "MARATHON_SERVICE_SCHEME_0": serviceScheme0,
+        }, 1)).to.eq(expectedSchemePort1);
+      });
+    });
+  });
+}
+
+function verifyServiceSchemeWithoutDefault(serviceScheme0, 
+  expectedSchemePort0, expectedSchemePort1) {
+  describe("MARATHON_SERVICE_SCHEME is not set", function() {
+    describe("MARATHON_SERVICE_SCHEME_0 is set to " + serviceScheme0, function() {
+      it("detect scheme of port 0", function() {
+        expect(ServiceSchemeUtil.getServiceSchemeFromLabels({
+          "MARATHON_SERVICE_SCHEME_0": serviceScheme0,
+        }, 0)).to.eq(expectedSchemePort0);
+      });
+
+      it("detect scheme of port 1", function() {
+        expect(ServiceSchemeUtil.getServiceSchemeFromLabels({
+          "MARATHON_SERVICE_SCHEME_0": serviceScheme0,
+        }, 1)).to.eq(expectedSchemePort1);
+      });
+    });
+  });
+}
+
+describe("ServiceSchemeUtil", function () {
+  //                             default scheme        scheme port 0       expected port 0             expected port 1
+  verifyServiceSchemeWithDefault("http",               "http",             "http",                     "http");
+  verifyServiceSchemeWithDefault("http",               "https",            "https",                    "http");
+  verifyServiceSchemeWithDefault("https",              "http",             "http",                     "https");
+  verifyServiceSchemeWithDefault("https",              "https",            "https",                    "https");
+
+  //                                scheme port 0       expected port 0             expected port 1
+  verifyServiceSchemeWithoutDefault("http",             "http",                     "http");
+  verifyServiceSchemeWithoutDefault("https",            "https",                    "http");
+  verifyServiceSchemeWithoutDefault("http",             "http",                     "http");
+  verifyServiceSchemeWithoutDefault("https",            "https",                    "http");
+});

--- a/src/test/units/TaskListItemComponent.test.js
+++ b/src/test/units/TaskListItemComponent.test.js
@@ -4,6 +4,7 @@ import {shallow} from "enzyme";
 import React from "react/addons";
 import TaskListItemComponent from "../../js/components/TaskListItemComponent";
 import Config from "../../js/config/config";
+import AppsStore from "../../js/stores/AppsStore";
 
 Config.taskLogsLinkGenerator = function (appId, taskId) {
   return "https://logs-store?appId=" + appId + "&taskId=" + taskId;
@@ -16,15 +17,16 @@ describe("Task List Item component", function () {
       appId: "/app-1",
       id: "task-123",
       host: "host-1",
-      ports: [1, 2, 3],
+      ports: [8081, 8082, 8083],
       status: "status-0",
       updatedAt: "2015-06-29T14:11:58.709Z",
-      version: "2015-06-29T13:54:24.171Z"
+      version: "2015-06-29T13:54:24.171Z",
     };
 
     this.component = shallow(
       <TaskListItemComponent appId={"/app-1"}
                              hasHealth={true}
+                             labels={{}}
                              taskHealthMessage="Healthy"
                              isActive={false}
                              onToggle={()=>{}}
@@ -41,6 +43,76 @@ describe("Task List Item component", function () {
       .text()
     ).to.equal("task-123");
   });
+
+  describe("service url are correct", function() {
+    function getNthServiceLink(component, n) {
+      return component.find("td")
+        .at(1).children()
+        .at(2).children()
+        .at(2 + n).children().first().props().href
+    }
+
+    it("has a HTTP service url when app does not have scheme label", function() {
+      expect(getNthServiceLink(this.component, 0)).to.equal("http://host-1:8081");
+      expect(getNthServiceLink(this.component, 1)).to.equal("http://host-1:8082");
+      expect(getNthServiceLink(this.component, 2)).to.equal("http://host-1:8083");
+    });
+
+    it("has only https schemes", function() {
+      var model = {
+        appId: "/app-1",
+        id: "task-123",
+        host: "host-1",
+        ports: [8081, 8082, 8083],
+        status: "status-0",
+        updatedAt: "2015-06-29T14:11:58.709Z",
+        version: "2015-06-29T13:54:24.171Z"
+      };
+  
+      this.component = shallow(
+        <TaskListItemComponent appId={"/app-1"}
+                               hasHealth={true}
+                               taskHealthMessage="Healthy"
+                               isActive={false}
+                               labels={{ 
+                                 "MARATHON_SERVICE_SCHEME": "https"
+                                }}
+                               onToggle={()=>{}}
+                               task={model} />
+      );
+      expect(getNthServiceLink(this.component, 0)).to.equal("https://host-1:8081");
+      expect(getNthServiceLink(this.component, 1)).to.equal("https://host-1:8082");
+      expect(getNthServiceLink(this.component, 2)).to.equal("https://host-1:8083");
+    })
+
+    it("has different schemes depending on the port", function() {
+      var model = {
+        appId: "/app-1",
+        id: "task-123",
+        host: "host-1",
+        ports: [8081, 8082, 8083],
+        status: "status-0",
+        updatedAt: "2015-06-29T14:11:58.709Z",
+        version: "2015-06-29T13:54:24.171Z"
+      };
+  
+      this.component = shallow(
+        <TaskListItemComponent appId={"/app-1"}
+                               hasHealth={true}
+                               taskHealthMessage="Healthy"
+                               isActive={false}
+                               labels={{ 
+                                 "MARATHON_SERVICE_SCHEME_0": "https",
+                                 "MARATHON_SERVICE_SCHEME_2": "http"
+                                }}
+                               onToggle={()=>{}}
+                               task={model} />
+      );
+      expect(getNthServiceLink(this.component, 0)).to.equal("https://host-1:8081");
+      expect(getNthServiceLink(this.component, 1)).to.equal("http://host-1:8082");
+      expect(getNthServiceLink(this.component, 2)).to.equal("http://host-1:8083");
+    })
+  })
 
   it("has correct health message", function () {
     expect(this.component.find("td").at(2).text()).to.equal("Healthy");


### PR DESCRIPTION
The service link in task view is always redirecting based on the scheme that is used by Marathon. However application might serve HTTP requests while Marathon could be served in HTTPS. This is the case for almost all apps at Criteo. Therefore, when you click on the service link for a given task in the task view, it fails and one must manually update the scheme of the url in the browser to fix the issue.

With this fix, the user can add the label "MARATHON_SERVICE_SCHEME" with value "http" or "https" to his app in order for the links to use this scheme. By default it uses the HTTP scheme.
FYI, this feature is implemented in DC/OS :).

In order to define the scheme by port, given the user wants to define the scheme of the n-th port, he can set the label MARATHON_SERVICE_SCHEME_<N> to "http" or "https".

I also edited the docker-compose file to make end-to-end tests easier using Docker images and the new runtimeConfig.js.