### PR TITLE
[UX] By default show latest updated tasks first

### DIFF
--- a/src/js/components/TaskListComponent.jsx
+++ b/src/js/components/TaskListComponent.jsx
@@ -27,7 +27,7 @@ var TaskListComponent = React.createClass({
   getInitialState: function () {
     return {
       sortKey: "updatedAt",
-      sortDescending: false
+      sortDescending: true
     };
   },
 


### PR DESCRIPTION
When going to marathon task list, are usually more interested in tasks
that started / are starting than by task that have not changed state for
a long time.

Change-Id: I7d8180903c9460ca9f17b8da9a3c3e149ff69eb1