### PR TITLE
Sort by hostname instead of task ID

### DIFF
--- a/src/js/components/TaskListComponent.jsx
+++ b/src/js/components/TaskListComponent.jsx
@@ -165,7 +165,7 @@ var TaskListComponent = React.createClass({
     });
 
     var idClassSet = classNames({
-      "cell-highlighted": state.sortKey === "id"
+      "cell-highlighted": state.sortKey === "host"
     });
 
     var statusClassSet = classNames("text-center", {
@@ -209,9 +209,9 @@ var TaskListComponent = React.createClass({
                   onChange={props.toggleAllTasks} />
               </th>
               <th className={idClassSet}>
-                <span onClick={this.sortBy.bind(null, "id")}
+                <span onClick={this.sortBy.bind(null, "host")}
                     className={headerClassSet}>
-                  ID {this.getCaret("id")}
+                  ID {this.getCaret("host")}
                 </span>
               </th>
               <th className={hasHealthClassSet}>

--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -230,7 +230,7 @@ var TaskListItemComponent = React.createClass({
     }
 
     var idClassSet = classNames({
-      "cell-highlighted": sortKey === "id"
+      "cell-highlighted": sortKey === "host"
     });
 
     var versionClassSet = classNames("text-right", {


### PR DESCRIPTION
When user click on "ID" column header in task list view, the real intent
is likely to sort by hostname instead of sorting by task id.
Marathon task id are ~random so sorting on them does not make sense.
Sorting on hostname actually makes more sense for people.

A better commit would sort on host+port but this one is likely good
enough.

Change-Id: Ia83cab32d4ac2353da07bc26ce8094c54d17c75e