### PR TITLE
Remove request to AppVersions on AppChange event

### DIFF
--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -163,11 +163,6 @@ var AppPageComponent = React.createClass({
       fetchState: States.STATE_SUCCESS,
       tabs: state.tabs
     });
-
-    if (state.view === "configuration") {
-      AppVersionsActions.requestAppVersions(state.appId);
-      AppVersionsActions.requestAppVersion(state.appId, app.version);
-    }
   },
 
   onAppRequestError: function (message, statusCode) {


### PR DESCRIPTION
Those requests are very specific for configuration Tab on a Application.
It generates a regular traffic which at some point accumulate some resources
which take more and more time to be processed by the browser.
In the end, we get a CPU hog which freeze the page