### PR TITLE
Fix DOM node leak

### DIFF
--- a/src/js/components/AppPageComponent.jsx
+++ b/src/js/components/AppPageComponent.jsx
@@ -163,6 +163,11 @@ var AppPageComponent = React.createClass({
       fetchState: States.STATE_SUCCESS,
       tabs: state.tabs
     });
+
+	if (state.view === "configuration") {
+      AppVersionsActions.requestAppVersions(state.appId);
+      AppVersionsActions.requestAppVersion(state.appId, app.version);
+    }
   },
 
   onAppRequestError: function (message, statusCode) {

--- a/src/js/components/AppVersionComponent.jsx
+++ b/src/js/components/AppVersionComponent.jsx
@@ -78,7 +78,11 @@ var AppVersionComponent = React.createClass({
   },
 
   componentDidUpdate: function () {
-    this.highlightNodes();
+	// Do not trigger highlightNodes for each update as it creates 
+	// nested spans which blows out the HTML DOM!
+	// side effects: if a new configuration is received it may not 
+	// be highlighted correctly but still readable.
+    // this.highlightNodes();
   },
 
   onAppApplySettingsRequest: function () {


### PR DESCRIPTION
On configuration tab, for a request update, highlighting nodes is triggered
each time, which generates nested span indefinitly. This in the end leads to
blow out the DOM tree of the browser, hogging the CPU.
This commit disables highlighting on update, but still triggers once
highlighting on some parameters (JSON)
Reverting last PR and reenabling AppVersion & AppChange requests