### PR TITLE
Fixed instance list URLs.

### DIFF
--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -90,7 +90,7 @@ var TaskListItemComponent = React.createClass({
 
       return (
         <span className="text-muted">
-          {task.host}:[{joinNodes(portNodes)}]
+          {task.ipAddresses[0].ipAddress}:[{joinNodes(portNodes)}]
         </span>
       );
     }

--- a/src/js/components/TaskListItemComponent.jsx
+++ b/src/js/components/TaskListItemComponent.jsx
@@ -79,9 +79,9 @@ var TaskListItemComponent = React.createClass({
           .getServiceSchemeFromLabels(props.labels, i);
         const name = getPortDecoration(props.portDefinitions, i, port);
         return (
-          <a key={`${task.host}:${port}`}
+          <a key={`${task.ipAddresses[0].ipAddress}:${port}`}
               className="text-muted"
-              href={`${scheme}://${task.host}:${port}`}
+              href={`${scheme}://${task.ipAddresses[0].ipAddress}:${port}`}
               target="_blank">
             {name}
           </a>

--- a/src/test/units/TaskListItemComponent.test.js
+++ b/src/test/units/TaskListItemComponent.test.js
@@ -24,6 +24,7 @@ describe("Task List Item component", function () {
       status: "status-0",
       updatedAt: "2015-06-29T14:11:58.709Z",
       version: "2015-06-29T13:54:24.171Z",
+      ipAddresses: [{ipAddress: "192.168.0.10", protocol: "IPv4"}]
     };
 
     this.component = shallow(
@@ -56,9 +57,9 @@ describe("Task List Item component", function () {
     }
 
     it("has a HTTP service url when app does not have scheme label", function() {
-      expect(getNthServiceLink(this.component, 0)).to.equal("http://host-1:8081");
-      expect(getNthServiceLink(this.component, 1)).to.equal("http://host-1:8082");
-      expect(getNthServiceLink(this.component, 2)).to.equal("http://host-1:8083");
+      expect(getNthServiceLink(this.component, 0)).to.equal("http://192.168.0.10:8081");
+      expect(getNthServiceLink(this.component, 1)).to.equal("http://192.168.0.10:8082");
+      expect(getNthServiceLink(this.component, 2)).to.equal("http://192.168.0.10:8083");
     });
 
     it("has only https schemes", function() {
@@ -69,7 +70,8 @@ describe("Task List Item component", function () {
         ports: [8081, 8082, 8083],
         status: "status-0",
         updatedAt: "2015-06-29T14:11:58.709Z",
-        version: "2015-06-29T13:54:24.171Z"
+        version: "2015-06-29T13:54:24.171Z",
+      	ipAddresses: [{ipAddress: "192.168.0.10", protocol: "IPv4"}]
       };
   
       this.component = shallow(
@@ -83,9 +85,9 @@ describe("Task List Item component", function () {
                                onToggle={()=>{}}
                                task={model} />
       );
-      expect(getNthServiceLink(this.component, 0)).to.equal("https://host-1:8081");
-      expect(getNthServiceLink(this.component, 1)).to.equal("https://host-1:8082");
-      expect(getNthServiceLink(this.component, 2)).to.equal("https://host-1:8083");
+      expect(getNthServiceLink(this.component, 0)).to.equal("https://192.168.0.10:8081");
+      expect(getNthServiceLink(this.component, 1)).to.equal("https://192.168.0.10:8082");
+      expect(getNthServiceLink(this.component, 2)).to.equal("https://192.168.0.10:8083");
     })
 
     it("has different schemes depending on the port", function() {
@@ -96,7 +98,8 @@ describe("Task List Item component", function () {
         ports: [8081, 8082, 8083],
         status: "status-0",
         updatedAt: "2015-06-29T14:11:58.709Z",
-        version: "2015-06-29T13:54:24.171Z"
+        version: "2015-06-29T13:54:24.171Z",
+      	ipAddresses: [{ipAddress: "192.168.0.10", protocol: "IPv4"}]
       };
   
       this.component = shallow(
@@ -111,9 +114,9 @@ describe("Task List Item component", function () {
                                onToggle={()=>{}}
                                task={model} />
       );
-      expect(getNthServiceLink(this.component, 0)).to.equal("https://host-1:8081");
-      expect(getNthServiceLink(this.component, 1)).to.equal("http://host-1:8082");
-      expect(getNthServiceLink(this.component, 2)).to.equal("http://host-1:8083");
+      expect(getNthServiceLink(this.component, 0)).to.equal("https://192.168.0.10:8081");
+      expect(getNthServiceLink(this.component, 1)).to.equal("http://192.168.0.10:8082");
+      expect(getNthServiceLink(this.component, 2)).to.equal("http://192.168.0.10:8083");
     })
   })
 


### PR DESCRIPTION
Instance list links should now point to the container's IP instead of
the host's.